### PR TITLE
pollable_fd_state: Mark destructor protected and make non-virtual

### DIFF
--- a/include/seastar/core/internal/pollable_fd.hh
+++ b/include/seastar/core/internal/pollable_fd.hh
@@ -62,7 +62,6 @@ using pollable_fd_state_ptr = boost::intrusive_ptr<pollable_fd_state>;
 class pollable_fd_state {
     unsigned _refs = 0;
 public:
-    virtual ~pollable_fd_state() {}
     struct speculation {
         int events = 0;
         explicit speculation(int epoll_events_guessed = 0) : events(epoll_events_guessed) {}
@@ -122,6 +121,7 @@ public:
 protected:
     explicit pollable_fd_state(file_desc fd, speculation speculate = speculation())
         : fd(std::move(fd)), events_known(speculate.events) {}
+    ~pollable_fd_state() = default;
 private:
     void maybe_no_more_recv();
     void maybe_no_more_send();


### PR DESCRIPTION
The pollable_fd_state is base class for backend-specific fd states. Those are created and destroyed via backend virtual calls. In that case, base class destructor doesn't need to be virtual, deleting an object via derived pointer would call correct destructor on its own. Also, the base class destructor is marked protected to explicitly disallow deletion via base-class.