### PR TITLE
Add default virtual destructors to promise_base classes

### DIFF
--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -117,6 +117,7 @@ public:
     generator_promise_base& operator=(const generator_promise_base &) = delete;
     generator_promise_base(generator_promise_base &&) noexcept = default;
     generator_promise_base& operator=(generator_promise_base &&) noexcept = default;
+    virtual ~generator_promise_base() = default;
 
     // lazily-started coroutine, do not execute the coroutine until
     // the coroutine is awaited.
@@ -513,6 +514,7 @@ public:
     generator_promise_base& operator=(const generator_promise_base &) = delete;
     generator_promise_base(generator_promise_base &&) noexcept = default;
     generator_promise_base& operator=(generator_promise_base &&) noexcept = default;
+    virtual ~generator_promise_base() = default;
 
     // lazily-started coroutine, do not execute the coroutine until
     // the coroutine is awaited.


### PR DESCRIPTION
Hello Kefu,

My linter complained about the absence of these destructors; I've added them.
In general, what is the status of this patch?

best, Niek